### PR TITLE
nextjs cache

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,5 +2,8 @@
   NODE_VERSION = "12"
 
 [build]
-  command = "rm -rf node_modules/.cache && node_modules/.bin/next build && node_modules/.bin/next export"
+  command = "node_modules/.bin/next build && node_modules/.bin/next export"
   publish = "out"
+
+[[plugins]]
+package = "netlify-plugin-cache-nextjs"


### PR DESCRIPTION
- do not remove `node_modules/.cache` containing the generated images
- add nextjs cache to reduce build time.