### PR TITLE
netlify: disable next cache

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,3 @@
 [build]
   command = "node_modules/.bin/next build && node_modules/.bin/next export"
   publish = "out"
-
-[[plugins]]
-package = "netlify-plugin-cache-nextjs"


### PR DESCRIPTION
missing `images` folder in deploy when nextjs cache is enabled